### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ This repository contains Algorithms implementation in Python 3
 All codes are supported for Python 3.5 onwards
 
 # List of Algorithms
-* Merge Sort: [mergesort.py](mergesort.py)
-* Quick Sort: [quicksort.py](quicksort.py)
-* Insertion Sort: [insertion_sort.py](insertion_sort.py)
-* Bubble Sort: [bubble_sort.py](bubble_sort.py)
+* Merge Sort: [mergesort.py](sort/mergesort.py)
+* Quick Sort: [quicksort.py](sort/quicksort.py)
+* Insertion Sort: [insertion_sort.py](sort/insertion_sort.py)
+* Bubble Sort: [bubble_sort.py](sort/bubble_sort.py)
 * Binary Search in Sorted List: [binary_search.py](binary_search.py)
 * Binary Tree: [binary_tree.py](binary_tree.py)
     * In-order traversal


### PR DESCRIPTION
I noticed that the links in the `README.md` file were broken for the algorithms in the `sort` folder. I tested it on the branch and all links should work now.
